### PR TITLE
Bug fix: spacing before headings

### DIFF
--- a/noindentafter.sty
+++ b/noindentafter.sty
@@ -47,7 +47,7 @@
 %
 %    \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{noindentafter}[2013/08/02 0.0.1
+\ProvidesPackage{noindentafter}[2014/11/30 0.0.2
   prevent paragraph indentation after specific environments or macros]
 %    \end{macrocode}
 %
@@ -65,10 +65,24 @@
 %
 %  We only need |etoolbox|. The definitions below can probably
 %  be rewritten not to need it, but for me it has not been
-%  worth the effort.
+%  worth the effort. Due to the modification of implemtentation, 
+%  |etoolbox| is absolutely necessary
+%  (\url{https://github.com/mhelvens/latex-noindentafter/pull/1}).
 %
 %    \begin{macrocode}
 \RequirePackage{etoolbox}
+%    \end{macrocode}
+%
+%  \noindent The package |etoolbox| provides the command
+%  |\AfterEndEnvironment| which crates a hook executed at 
+%  a very late point by the |\end| command. However, this 
+%  hook is invoked before |\ignorespaces|, which is too early 
+%  to suppress the indention after an environment. Therefore 
+%  another hook to |\end| is added with |\patchcmd| after 
+%  |\ignorespaces|. This new hook is executed last at the end 
+%  of an environment.
+%
+%    \begin{macrocode}
 \patchcmd\end{%
   \if@ignore\@ignorefalse\ignorespaces\fi%
 }{%
@@ -92,6 +106,16 @@
 
 
 
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  % \needspace{5\baselineskip}\begin{macro}{\@NoIndentAfter}
+%
+%  \noindent This is the main part of this package. The command
+%  |\@NoIndentAfter| checks, if it's followed by an paragraph.
+%  In this case, the command |\par| is temporarily changed, so 
+%  that the following paragraph is not indented. Therefore, 
+%  |\everypar| is used. After that, the default behavior is 
+%  restored with |\@restorepar|.
+%
 %    \begin{macrocode}
 \newcommand*\@NoIndentAfter{%
   \@ifnextchar\par{%
@@ -102,6 +126,10 @@
   }{}%
 }
 %    \end{macrocode}
+%
+%\end{macro}%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% \needspace{5\baselineskip}\begin{macro}{\NoIndentAfterThis}
 %
@@ -119,7 +147,7 @@
   % \needspace{5\baselineskip}\begin{macro}{\NoIndentAfterEnv}
 %%% \marg{environment}\\
 %
-%  \noindent Append |\NoIndentAfterThis| to the output of
+%  \noindent Append |\@NoIndentAfter| to the output of
 %  \meta{environment}.
 % 
 %    \begin{macrocode}


### PR DESCRIPTION
To prevent an indention, the command \par is temporarily changed instead of using \@afterindent\@afterheading
