### PR TITLE
fix for newer LaTeX versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 latex-noindentafter
 ===============
 
-LaTeX Package : noindentafter 0.2.2
+LaTeX Package : noindentafter 0.2.3
 
-Last Modified : 2014/11/30
+Last Modified : 2020/07/19
 
 Author        : Michiel Helvensteijn  (www.mhelvens.net)
 

--- a/archive
+++ b/archive
@@ -11,7 +11,7 @@ FILES="$DOC.sty         \
        $DOC-packagedoc.cls  \
        README.md"
 
-VERSION=0.2.2
+VERSION=0.2.3
 
 ##################################################
 #

--- a/noindentafter.sty
+++ b/noindentafter.sty
@@ -89,7 +89,7 @@
 %  end.
 %
 %    \begin{macrocode}
-\patchcmd\end{%
+\expandafter\patchcmd\csname end \endcsname{%
   \if@ignore\@ignorefalse\ignorespaces\fi%
 }{%
   \if@ignore\@ignorefalse\ignorespaces\fi%

--- a/noindentafter.tex
+++ b/noindentafter.tex
@@ -43,6 +43,8 @@
   {new implementation, fixing a spacing issue}
 \changes{0.2.2}{2014/11/30}
   {fixed version number in the README}
+\changes{0.2.3}{2020/07/19}
+  {fix for newer LaTeX versions}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}                                                               %


### PR DESCRIPTION
The \NoIndentAfterEnv macro stopped working correctly last November, see [this issue on stackexchange](https://tex.stackexchange.com/questions/514127/incompatibility-between-noindentafter-and-etoolbox-v2-5f) about it. And you get the warning from the package even when \NoIndentAfterEnv is not used, just as long as the package is included.

This PR contain the fix from that stackexchange answer.


Unrelated to the issue, but when I run `./archive` or use pdflatex to generate the pdf, all code examples look identical to the first one. I get this warning several times:
```
LaTeX Warning: File `Unique-CS-Name-(2).tmp' already exists on the system. Not generating it from this source.
```
That file contains the first code example.