### PR TITLE
Update for kernel 2019/10/01 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 latex-noindentafter
 ===============
 
-LaTeX Package : noindentafter 0.2.2
+LaTeX Package : noindentafter 0.3.0
 
-Last Modified : 2014/11/30
+Last Modified : 2021/02/11
 
 Author        : Michiel Helvensteijn  (www.mhelvens.net)
 

--- a/archive
+++ b/archive
@@ -11,7 +11,7 @@ FILES="$DOC.sty         \
        $DOC-packagedoc.cls  \
        README.md"
 
-VERSION=0.2.2
+VERSION=0.3.0
 
 ##################################################
 #

--- a/noindentafter-dry.sty
+++ b/noindentafter-dry.sty
@@ -27,7 +27,6 @@
 \ProvidesPackage{noindentafter-dry}
   [2013/10/11 convenience macros for reusing LaTeX code]
 
-\RequirePackage{filecontents}
 \RequirePackage{xparse}
 \RequirePackage{etoolbox}
 \RequirePackage{withargs}
@@ -40,7 +39,7 @@
   \withargs [\uniquecsname] [#2] {%
     \newenvironment{#1}{%
       \begingroup%
-      \@tempswafalse\filec@ntents{##1.tmp}%
+      \filecontents[noheader,force]{##1.tmp}%
     }{%
       \endfilecontents%
       \endgroup%

--- a/noindentafter-packagedoc.cls
+++ b/noindentafter-packagedoc.cls
@@ -86,8 +86,8 @@
     \small
     \begin{center}
       Development of this package is organized at
-      \href{http://latex-\packagename.googlecode.com}
-                  {latex-\packagename.googlecode.com}.\\
+      \href{https://github.com/mhelvens/latex-noindentafter}
+                  {github.com/mhelvens/latex-noindentafter}.\\
       I am happy to receive feedback there!
     \end{center}
   \end{bannerframe}
@@ -286,12 +286,12 @@
 
 \newcommand{\describemacro}[2]{%
   \needspace{3\baselineskip}%
-  \noindent\\\DescribeMacro{#1} #2\\%
+  \noindent\\\DescribeMacro{#1} #2\par\medskip%
 }
 
 \newcommand{\describemetamacro}[2]{%
   \needspace{3\baselineskip}%
-  \noindent\\\marginnote{\meta{#1}} #2\\%
+  \noindent\\\marginnote{\meta{#1}} #2\par\medskip%
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/noindentafter-with.sty
+++ b/noindentafter-with.sty
@@ -2,7 +2,7 @@
 %                                                                              %
 %  Copyright (c) 2013 - Michiel Helvensteijn   (www.mhelvens.net)              %
 %                                                                              %
-%  http://latex-with.googlecode.com                                            %
+%  https://github.com/mhelvens/latex-noindentafter
 %                                                                              %
 %  This work may be distributed and/or modified under the conditions           %
 %  of the LaTeX Project Public License, either version 1.3 of this             %

--- a/noindentafter.sty
+++ b/noindentafter.sty
@@ -2,7 +2,7 @@
 %                                                                              %
 %  Copyright (c) 2014 - Michiel Helvensteijn - www.mhelvens.net                %
 %                                                                              %
-%  http://latex-noindentafter.googlecode.com                                   %
+%  https://github.com/mhelvens/latex-noindentafter                             %
 %                                                                              %
 %  This work may be distributed and/or modified under the conditions           %
 %  of the LaTeX Project Public License, either version 1.3 of this             %
@@ -72,41 +72,6 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% \subsection{Patches}                                                         %
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%% \needspace{5\baselineskip}\begin{macro}{\end}
-%
-%  The package |etoolbox| provides the command
-%  |\AfterEndEnvironment| which creates a hook executed at a
-%  very late point inside the |\end| command. However, this
-%  hook is still located before |\ignorespaces|, which is
-%  too early to properly suppress the indention after an
-%  environment. Therefore another hook is now added to |\end|
-%  using |\patchcmd|. This new hook puts new code at the very
-%  end.
-%
-%    \begin{macrocode}
-\patchcmd\end{%
-  \if@ignore\@ignorefalse\ignorespaces\fi%
-}{%
-  \if@ignore\@ignorefalse\ignorespaces\fi%
-  \csuse{@noindent@#1@hook}%
-}{}{%
-  \PackageWarningNoLine{noindentafter}{%
-    Patching `\string\end' failed!\MessageBreak%
-    `\string\NoIndentAfter...' commands won't work%
-  }%
-}
-%    \end{macrocode}
-%
-%\end{macro}%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \subsection{Macros}                                                          %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -124,12 +89,37 @@
 %
 %    \begin{macrocode}
 \newcommand*\@NoIndentAfter{%
-  \@ifnextchar\par{%
+  \kernel@ifnextchar\par{%
+    \par%
     \def\par{%
       \everypar{\setbox\z@\lastbox\everypar{}}%
       \@restorepar%
     }%
   }{}%
+}
+%    \end{macrocode}
+%
+%\end{macro}%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% \needspace{5\baselineskip}\begin{macro}{\@NoIndentAfterEnv}
+%
+%  \noindent This command is used for hooking into the ending
+%  routine of an environment at the latest possible point after
+%  |\ignorespaces|. It is heavily inspired by David Carlisle
+%  (\url{https://tex.stackexchange.com/a/179034/38481}) and 
+%  uses a delimited argument in order to apply |\@NoIndentAfter|
+%  last. It is invoked through the hook |\AfterEndEnvironment| 
+%  provided by package package |etoolbox| and leaves everything 
+%  between its invocation and |\ignorespaces\fi| at the very end
+%  of command |\end| unchanged---even additonal material given
+%  through the same hook---and finally executes |\@NoIndentAfter|
+%
+%    \begin{macrocode}
+\newcommand*\@NoIndentAfterEnv{}
+\def\@NoIndentAfterEnv#1\ignorespaces\fi{%
+  #1\ignorespaces\fi\@NoIndentAfter%
 }
 %    \end{macrocode}
 %
@@ -143,7 +133,7 @@
 %  indentation for whatever follows.
 % 
 %    \begin{macrocode}
-\newrobustcmd*{\NoIndentAfterThis}{\@NoIndentAfter\par\par}
+\newrobustcmd*\NoIndentAfterThis{\@NoIndentAfter\par}
 %    \end{macrocode}
 % 
 %\end{macro}%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -151,14 +141,15 @@
 
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % \needspace{5\baselineskip}\begin{macro}{\NoIndentAfterEnv}
-%%% \marg{environment}\\
+%%% \marg{environment}\par\medskip
 %
-%  \noindent Append |\@NoIndentAfter| to the output of
-%  \meta{environment} by using the new environment hook.
+%  \noindent Append |\@NoIndentAfterEnv| to the output of
+%  \meta{environment} by using the environment hook.
+%  
 % 
 %    \begin{macrocode}
-\newrobustcmd{\NoIndentAfterEnv}[1]{%
-  \csdef{@noindent@#1@hook}{\@NoIndentAfter}%
+\newcommand*\NoIndentAfterEnv[1]{%
+  \AfterEndEnvironment{#1}{\@NoIndentAfterEnv}%
 }
 %    \end{macrocode}
 % 
@@ -167,14 +158,14 @@
 
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   % \needspace{5\baselineskip}\begin{macro}{\NoIndentAfterCmd}
-%%% \marg{command}\\
+%%% \marg{command}\par\medskip
 %
 %  \noindent Append |\NoIndentAfterThis| to the output of
 %  \meta{command}.
 % 
 %    \begin{macrocode}
-\newrobustcmd*{\NoIndentAfterCmd}[1]{%
-  \apptocmd{#1}{\NoIndentAfterThis}{}{%
+\newcommand*\NoIndentAfterCmd[1]{%
+  \apptocmd#1{\NoIndentAfterThis}{}{%
     \PackageWarning{noindentafter}{%
       Patching `\string#1' failed!\MessageBreak%
       `\string\NoIndentAfterCmd' won't work%

--- a/noindentafter.sty
+++ b/noindentafter.sty
@@ -47,7 +47,7 @@
 %
 %    \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{noindentafter}[2014/11/30 0.2.2
+\ProvidesPackage{noindentafter}[2021/02/11 0.3.0
   prevent paragraph indentation after specific environments or macros]
 %    \end{macrocode}
 %
@@ -143,8 +143,8 @@
   % \needspace{5\baselineskip}\begin{macro}{\NoIndentAfterEnv}
 %%% \marg{environment}\par\medskip
 %
-%  \noindent Append |\@NoIndentAfterEnv| to the output of
-%  \meta{environment} by using the environment hook.
+%  \noindent Append |\@NoIndentAfterEnv| to the very end of
+%  \meta{environment}.
 %  
 % 
 %    \begin{macrocode}

--- a/noindentafter.tex
+++ b/noindentafter.tex
@@ -2,7 +2,7 @@
 %                                                                              %
 %  Copyright (c) 2014 - Michiel Helvensteijn - www.mhelvens.net                %
 %                                                                              %
-%  http://latex-noindentafter.googlecode.com                                   %
+%  https://github.com/mhelvens/latex-noindentafter
 %                                                                              %
 %  This work may be distributed and/or modified under the                      %
 %  conditions of the LaTeX Project Public License, either                      %
@@ -30,7 +30,7 @@
 \NoIndentAfterCmd{\describemacro}
 
 \moretexcs{%
-	NoIndentAfterThis,NoIndentAfterEnv,NoIndentAfterCmd
+  NoIndentAfterThis,NoIndentAfterEnv,NoIndentAfterCmd
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -79,10 +79,10 @@ This is the most primitive macro offered by the package. It forces a
 paragraph break and suppresses indentation for whatever follows:
 
 \begin{latex-example-show}
-	Lorem ipsum dolor sit amet, consectetur adipiscing
-	elit. \NoIndentAfterThis Pellentesque hendrerit volutpat
-	feugiat. Ut purus leo, pulvinar sit amet vehicula non,
-	pulvinar eu lacus. Curabitur id mollis ligula.
+  Lorem ipsum dolor sit amet, consectetur adipiscing
+  elit. \NoIndentAfterThis Pellentesque hendrerit volutpat
+  feugiat. Ut purus leo, pulvinar sit amet vehicula non,
+  pulvinar eu lacus. Curabitur id mollis ligula.
 \end{latex-example-show}
 
 
@@ -99,29 +99,29 @@ name. After using this command, any paragraph following such
 an environment will remain unindented.
 
 \begin{latex-example-show}
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-	
-	\begin{itemize}
-	  \item First Item
-	  \item Second Item
-	\end{itemize}
-	
-	Pellentesque hendrerit volutpat feugiat. Ut purus
-	leo, pulvinar sit amet vehicula non, pulvinar eu
-	lacus. Curabitur id mollis ligula.
-	
-	\NoIndentAfterEnv{itemize}
-	
-	Vestibulum id erat venenatis, facilisis enim non,
-	consectetur felis. Quisque iaculis eu arcu non pretium.
-	
-	\begin{itemize}
-	  \item Third Item
-	  \item Fourth Item
-	\end{itemize}
-	
-	Curabitur est elit, posuere pulvinar laoreet sed, varius
-	id mi. Nam lobortis elit nec mauris condimentum gravida.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  
+  \begin{itemize}
+    \item First Item
+    \item Second Item
+  \end{itemize}
+  
+  Pellentesque hendrerit volutpat feugiat. Ut purus
+  leo, pulvinar sit amet vehicula non, pulvinar eu
+  lacus. Curabitur id mollis ligula.
+  
+  \NoIndentAfterEnv{itemize}
+  
+  Vestibulum id erat venenatis, facilisis enim non,
+  consectetur felis. Quisque iaculis eu arcu non pretium.
+  
+  \begin{itemize}
+    \item Third Item
+    \item Fourth Item
+  \end{itemize}
+  
+  Curabitur est elit, posuere pulvinar laoreet sed, varius
+  id mi. Nam lobortis elit nec mauris condimentum gravida.
 \end{latex-example-show}
 
 You'll probably want to use these commands in the document
@@ -133,16 +133,16 @@ environment is not the same as adding |\NoIndentAfterThis|
 to the end of it:
 
 \begin{latex-example-show}
-	\newenvironment{test}{\itshape}{\NoIndentAfterThis}
-	
-	\begin{test}
-	    Lorem ipsum dolor sit amet, consectetur
-	    adipiscing elit.
-	\end{test}
-	
-	Pellentesque hendrerit volutpat feugiat. Ut purus
-	leo, pulvinar sit amet vehicula non, pulvinar eu
-	lacus. Curabitur id mollis ligula.
+  \newenvironment{test}{\itshape}{\NoIndentAfterThis}
+  
+  \begin{test}
+      Lorem ipsum dolor sit amet, consectetur
+      adipiscing elit.
+  \end{test}
+  
+  Pellentesque hendrerit volutpat feugiat. Ut purus
+  leo, pulvinar sit amet vehicula non, pulvinar eu
+  lacus. Curabitur id mollis ligula.
 \end{latex-example-show}
 
 |\NoIndentAfterEnv| works because it bypasses the group
@@ -158,18 +158,18 @@ Finally, you may also patch command sequences using the
 where this is useful, but for me, there is at least one:
 
 \begin{latex-example-show}
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit:
-	
-	\[ 1 + 1 = 2 \]
-	
-	Pellentesque hendrerit volutpat feugiat. Ut purus leo:
-	
-	\NoIndentAfterCmd \]
-	
-	\[ 2 + 2 = 4 \]
-	
-	Vestibulum id erat venenatis, facilisis enim non,
-	consectetur felis.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit:
+  
+  \[ 1 + 1 = 2 \]
+  
+  Pellentesque hendrerit volutpat feugiat. Ut purus leo:
+  
+  \NoIndentAfterCmd \]
+  
+  \[ 2 + 2 = 4 \]
+  
+  Vestibulum id erat venenatis, facilisis enim non,
+  consectetur felis.
 \end{latex-example-show}
 
 Note that braces around the \meta{command} argument are

--- a/noindentafter.tex
+++ b/noindentafter.tex
@@ -43,6 +43,8 @@
   {new implementation, fixing a spacing issue}
 \changes{0.2.2}{2014/11/30}
   {fixed version number in the README}
+\changes{0.3.0}{2021/02/11}
+  {adaptations to kernel 2019/10/01 and later}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}                                                               %
@@ -194,10 +196,11 @@ This package was originally based on the technique proposed by cgnieder, as
 it is simpler and more generally applicable. Still, the answer by lockstep
 is definitely worth a read.
 
-Most recently, a better approach was implemented by tudscr to fix the spacing
-above headers:
+Most recently, a better approach was implemented by mrpiggi to fix the spacing
+above headers as well as consider changes to kernel with 2019/10/01 and later:
 \begin{itemize}
   \item \url{https://github.com/mhelvens/latex-noindentafter/pull/1}
+  \item \url{https://github.com/mhelvens/latex-noindentafter/pull/4}
 \end{itemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
There is already an open PR #3 but this one will also work for rollbacks with `latexrelease`, at least when https://github.com/latex3/latex2e/issues/494 was resolved by shipping https://github.com/latex3/latex2e/commit/99f135ec5f6a814b4959857143f7889435f8a67c to CTAN.

For now it works with the current kernel. Additionally, it get's rid of patching the internal command `\end` by using a more elegant approach provided by David Carlisle @davidcarlisle right here: https://tex.stackexchange.com/a/179034/38481